### PR TITLE
Use win-spawn for windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "check-more-types": "2.1.2",
     "lazy-ass": "0.6.0",
     "q": "1.4.1",
-    "verbal-expressions": "0.1.2"
+    "verbal-expressions": "0.1.2",
+    "win-spawn": "^2.0.0"
   },
   "devDependencies": {
     "codacy-coverage": "1.1.3",

--- a/src/npm-test.js
+++ b/src/npm-test.js
@@ -1,6 +1,6 @@
 require('lazy-ass');
 var check = require('check-more-types');
-var spawn = require('child_process').spawn;
+var spawn = require('win-spawn');
 var q = require('q');
 var NPM_PATH = require('./npm-path');
 


### PR DESCRIPTION
Spawning `npm test` using node.js's spawn fails on windows.