### PR TITLE
feat(publish): add support for package access

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -15,6 +15,12 @@ function publish (options) {
     debug('publishing with a tag', options.tag)
     command += ' --tag ' + options.tag
   }
+
+  if (is.unemptyString(options.access)) {
+    debug('publishing with specific access', options.access)
+    command += ' --access ' + options.access
+  }
+
   return run(command)
     .catch(function (info) {
       debug('publishing hit an error')


### PR DESCRIPTION
NPM added a new option to publish that allows the user to specify
whether their package is public or private. This is primarily meant for
use with organizations. Now that organizations are a public feature,
this is a more commonly used option.

Further information on the option can be found in the official
documentation: https://docs.npmjs.com/cli/publish