### PR TITLE
chore(package): upgrade repo-url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "local-or-home-npmrc": "github:bahmutov/local-or-home-npmrc",
     "q": "2.0.3",
     "registry-url": "3.1.0",
-    "repo-url": "1.0.0",
+    "repo-url": "1.0.1",
     "verbal-expressions": "0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading this dependency to silent deprecation notices from Node about `os.tmpDir()`.

See https://github.com/juliangruber/repo-url/commit/ea72183cbb4437fc57f870cd8fb36b779fa2f9af for specific change.