### PR TITLE
fix(setAuthToken): use publishConfig registry URL

### DIFF
--- a/src/set-auth-token-spec.js
+++ b/src/set-auth-token-spec.js
@@ -3,6 +3,7 @@ var path = require('path')
 var proxyquire = require('proxyquire')
 var temp = require('temp')
 const chdir = require('chdir-promise')
+const la = require('lazy-ass')
 
 temp.track()
 
@@ -53,6 +54,23 @@ describe('set auth token', () => {
       .then(function () {
         var npmrcContents = fs.readFileSync(npmrcPath, 'utf8')
         console.log(npmrcContents)
+        la(npmrcContents.includes('//npm.example.com/:_authToken='))
+      })
+  })
+
+  it('sets the authentication token based on publishConfig URL', function () {
+    var customRegistry = 'https://npm.example.com/'
+    var npmrcPath = path.join(dirPath, '.npmrc')
+    var packagePath = path.join(dirPath, 'package.json')
+
+    fs.writeFileSync(npmrcPath, '@myco:registry=' + customRegistry, { encoding: 'utf8' })
+    fs.writeFileSync(packagePath, '{ "name": "@myco/test-package", "publishConfig": { "registry": "https://private.example.com/" } }', { encoding: 'utf8' })
+
+    return setAuthToken()
+      .then(function () {
+        var npmrcContents = fs.readFileSync(npmrcPath, 'utf8')
+        console.log(npmrcContents)
+        la(npmrcContents.includes('//private.example.com/:_authToken='))
       })
   })
 })


### PR DESCRIPTION
If set, prefer the value of the `packageConfig.registry` property
over the value of the registry as set in the user's `.npmrc` file.

In one scenario, a package may fetch its dependencies from a virtual
registry that is an overlay of a private registry over the public npm
registry. Yet, that package is configured to publish directly to the
private registry URL. To account for this scenario we need to get the
value of the private registry URL and configure it within the
`.npmrc` file.

BREAKING CHANGE:

`setAuthToken` will not prefer the URL value of the
`publishConfig.registry` property in a package's `package.json` file.

Fixes #33 