### PR TITLE
fix(pack): replace symbols for scoped names

### DIFF
--- a/src/pack.js
+++ b/src/pack.js
@@ -9,7 +9,7 @@ var getPackage = require('./get-package')
 // NPM pack generates file in the format
 // <name>-<version>.tgz
 function formTarballName (pkg) {
-  return pkg.name + '-' + pkg.version + '.tgz'
+  return pkg.name.replace('@', '').replace('/', '-') + '-' + pkg.version + '.tgz'
 }
 
 function pack (options) {


### PR DESCRIPTION
The `pack` function tries to resolve the result of the `npm pack` as `${package.name}-${package.version}.tgz`, but when `package.name` has a scope, the npm cli generates the tarball without the `@`, and switching `/` with `-`, i.e. `@abc/xyz` becomes `abc-xyz`.